### PR TITLE
Remove docs for pricebook post

### DIFF
--- a/api.json
+++ b/api.json
@@ -1879,33 +1879,6 @@
           }
         }
       },
-      "post": {
-        "description": "Creates a new price book.",
-        "summary": "Create a price book",
-        "tags": [
-          "Price Books"
-        ],
-        "operationId": "CreatePriceBook",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/PriceBookBase"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "",
-            "schema": {
-              "$ref": "#/definitions/PriceBookResponse"
-            }
-          }
-        }
-      }
     },
     "/price_books/{price_book_id}": {
       "get": {


### PR DESCRIPTION
Removing documentation for an endpoint (POST /api/2.0/price_books) which will be removed by https://github.com/vend/vend/pull/13563. 